### PR TITLE
Add rel attribute to social links

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -155,7 +155,7 @@ function suki_social_links( $links = array(), $args = array(), $echo = true ) {
 	foreach ( $links as $link ) :
 		echo ( $args['before_link'] ); // WPCS: XSS OK
 
-		?><a href="<?php echo esc_url( $link['url'] ); ?>" class="suki-social-link" <?php '_blank' === suki_array_value( $link, 'target', '_self' ) ? ' target="_blank" rel="noopener"' : ''; ?>>
+		?><a href="<?php echo esc_url( $link['url'] ); ?>" rel="nofollow" class="suki-social-link" <?php '_blank' === suki_array_value( $link, 'target', '_self' ) ? ' target="_blank" rel="noopener"' : ''; ?>>
 			<?php suki_icon( $link['type'], array( 'title' => $labels[ $link['type'] ], 'class' => $args['link_class'] ) ); ?>
 		</a><?php
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -155,7 +155,7 @@ function suki_social_links( $links = array(), $args = array(), $echo = true ) {
 	foreach ( $links as $link ) :
 		echo ( $args['before_link'] ); // WPCS: XSS OK
 
-		?><a href="<?php echo esc_url( $link['url'] ); ?>" rel="me nofollow noopener" class="suki-social-link" <?php '_blank' === suki_array_value( $link, 'target', '_self' ) ? ' target="_blank" rel="noopener"' : ''; ?>>
+		?><a href="<?php echo esc_url( $link['url'] ); ?>" class="suki-social-link" <?php '_blank' === suki_array_value( $link, 'target', '_self' ) ? ' target="_blank" rel="noopener me nofollow"' : ' rel="me nofollow"'; ?>>
 			<?php suki_icon( $link['type'], array( 'title' => $labels[ $link['type'] ], 'class' => $args['link_class'] ) ); ?>
 		</a><?php
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -155,7 +155,7 @@ function suki_social_links( $links = array(), $args = array(), $echo = true ) {
 	foreach ( $links as $link ) :
 		echo ( $args['before_link'] ); // WPCS: XSS OK
 
-		?><a href="<?php echo esc_url( $link['url'] ); ?>" rel="nofollow" class="suki-social-link" <?php '_blank' === suki_array_value( $link, 'target', '_self' ) ? ' target="_blank" rel="noopener"' : ''; ?>>
+		?><a href="<?php echo esc_url( $link['url'] ); ?>" rel="me nofollow noopener" class="suki-social-link" <?php '_blank' === suki_array_value( $link, 'target', '_self' ) ? ' target="_blank" rel="noopener"' : ''; ?>>
 			<?php suki_icon( $link['type'], array( 'title' => $labels[ $link['type'] ], 'class' => $args['link_class'] ) ); ?>
 		</a><?php
 


### PR DESCRIPTION
- `rel="nofollow"` to improve SEO.
- `rel="me"` to tell Google that you're not just linking to those pages, but you actually control them. [reference](https://www.smartinsights.com/search-engine-optimisation-seo/index-inclusion/google-rel-me/)
- `rel="noopener"` for security.