### PR TITLE
Add accessible label to suki-social-links

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -207,6 +207,7 @@ function suki_social_links( $links = array(), $args = array(), $echo = true ) {
 
 		?><a href="<?php echo esc_url( $link['url'] ); ?>" class="suki-social-link <?php echo esc_attr( 'suki-social-link--' . $link['type'] ); ?>" <?php echo '_blank' === suki_array_value( $link, 'target', '_self' ) ? ' target="_blank" rel="noopener"' : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<?php suki_icon( $link['type'], array( 'title' => $labels[ $link['type'] ], 'class' => $args['link_class'] ) ); ?>
+			<span class="screen-reader-text"><?php echo $labels[ $link['type'] ]; ?></span>
 		</a><?php
 
 		echo $args['after_link']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
Suki social links do not currently have discernable names, resulting in screen readers to read aloud their full URLs. I've added a simple fix for this by adding hidden .screen-reader-text labels inside of these links.